### PR TITLE
Clean up website

### DIFF
--- a/HVZ.Persistence.MongoDB/Repos/UserRepo.cs
+++ b/HVZ.Persistence.MongoDB/Repos/UserRepo.cs
@@ -63,7 +63,8 @@ public class UserRepo : IUserRepo
         User user = new(
             id: string.Empty,
             fullName: name,
-            email: email
+            email: email,
+            createdAt: _clock.GetCurrentInstant()
         );
         _logger.LogTrace($"Creating new user: name: {name} | email: {email}");
         await Collection.InsertOneAsync(user);

--- a/HVZ.Persistence/Models/User.cs
+++ b/HVZ.Persistence/Models/User.cs
@@ -20,10 +20,11 @@ public class User : IdEquatable<User>
     /// </summary>
     public Instant CreatedAt { get; init; }
 
-    public User(string id, string fullName, string email)
+    public User(string id, string fullName, string email, Instant createdAt)
     {
         Id = id;
         FullName = fullName;
         Email = email;
+        CreatedAt = createdAt;
     }
 }

--- a/HVZ.Tests/HVZ.Web.Components.Tests/ComponentTestBase.razor
+++ b/HVZ.Tests/HVZ.Web.Components.Tests/ComponentTestBase.razor
@@ -83,7 +83,8 @@
             base(
                 id: testUserId,
                 fullName: testUserFullName,
-                email: testUserEmail)
+                email: testUserEmail,
+                createdAt: time)
         {
 
         }

--- a/HVZ.Tests/HVZ.Web.Components.Tests/ManageModsSettingsTest.razor
+++ b/HVZ.Tests/HVZ.Web.Components.Tests/ManageModsSettingsTest.razor
@@ -15,7 +15,7 @@
             new Mock<IUserStore<ApplicationUser>>().Object,
                 null, null, null, null, null, null, null, null);
     
-    User defaultUser = new User("0", "Default User", "default.user@mail.tld");
+    User defaultUser = new User("0", "Default User", "default.user@mail.tld", NodaTime.Instant.MinValue);
 
     readonly string orgId = "0";
 

--- a/HVZ.Tests/HVZ.Web.Components.Tests/UserListItemTest.razor
+++ b/HVZ.Tests/HVZ.Web.Components.Tests/UserListItemTest.razor
@@ -1,7 +1,6 @@
 @using HVZ.Web.Services
 @using HVZ.Web.Shared.Users
 @inherits Bunit.TestContext
-
 @code
 {
     string orgId = "0";
@@ -14,7 +13,7 @@
     Mock<ImageService> mockImageSerice = new Mock<ImageService>();
 
     // Use in instances where information about the user is not relevant
-    User defaultUser = new User("0", "Default User", "default.user@mail.tld");
+    User defaultUser = new User("0", "Default User", "default.user@mail.tld", NodaTime.Instant.MinValue);
 
     [OneTimeSetUp]
     public void Setup()

--- a/HVZ.Web/Pages/About.razor
+++ b/HVZ.Web/Pages/About.razor
@@ -10,7 +10,6 @@
 <div class="container">
     <h1>Welcome to PlayHVZ.org</h1>
     @*This lives here for now until we create a settings page*@
-    <HVZ.Web.Shared.Ui_Helpers.ThemeToggle />
     <p class="mb-3">PlayHVZ is a tool for managing games of Humans vs Zombies.</p>
     <CascadingAuthenticationState>
 

--- a/HVZ.Web/Pages/Index.razor
+++ b/HVZ.Web/Pages/Index.razor
@@ -44,7 +44,7 @@
         }
         else
         {
-            <p>Games you are participating in will appear here.</p>
+            <p class="text-lg-center">Games you are participating in will appear here.</p>
         }
 
     </div>

--- a/HVZ.Web/Shared/Game/GameLogView.razor
+++ b/HVZ.Web/Shared/Game/GameLogView.razor
@@ -26,12 +26,29 @@
 
     protected override void OnParametersSet()
     {
-        eventLog = ActiveGame.EventLog;
+        eventLog = GetEventLog();
 
         GameRepo.PlayerJoinedGame += PlayerUpdatedEvent;
         GameRepo.TagLogged += PlayerTaggedEvent;
         GameRepo.PlayerRoleChanged += PlayerRoleChangedByModEvent;
         GameRepo.GameActiveStatusChanged += GameStatusChagned;
+    }
+
+    List<GameEventLog> GetEventLog()
+    {
+        if (SeesOzDetails) return ActiveGame.EventLog;
+
+        return ActiveGame.EventLog.Where(
+            e => !EventIsOzStatusChange(e) || (EventIsOzStatusChange(e) && SeesOzDetails)
+        ).ToList();
+    }
+
+    bool EventIsOzStatusChange(GameEventLog e)
+    {
+        if (e.GameEvent != GameEvent.ActiveStatusChanged) return false;
+
+        Player.gameRole targetRole = (Player.gameRole)e.AdditionalInfo["role"];
+        return targetRole == Player.gameRole.Oz;
     }
 
     void PlayerUpdatedEvent(object? sender, PlayerUpdatedEventArgs args)

--- a/HVZ.Web/Shared/Game/GameLogView.razor
+++ b/HVZ.Web/Shared/Game/GameLogView.razor
@@ -47,8 +47,7 @@
     {
         if (e.GameEvent != GameEvent.ActiveStatusChanged) return false;
 
-        Player.gameRole targetRole = (Player.gameRole)e.AdditionalInfo["role"];
-        return targetRole == Player.gameRole.Oz;
+        return (Player.gameRole)e.AdditionalInfo["role"] is Player.gameRole.Oz;
     }
 
     void PlayerUpdatedEvent(object? sender, PlayerUpdatedEventArgs args)

--- a/HVZ.Web/Shared/Game/PlayerListItem.razor
+++ b/HVZ.Web/Shared/Game/PlayerListItem.razor
@@ -97,6 +97,15 @@
         GameRepo.PlayerRoleChanged += RoleChangedByMod;
     }
 
+    // Not ideal but it will have to do for now
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            playerUser = await UserRepo.GetUserById(Player.UserId);
+        }
+    }
+
     void PlayerTagged(object? sender, TagEventArgs args)
     {
         UserRoleChanged(args.TagReciever, args.game.Id);

--- a/HVZ.Web/Shared/Navigation/Footer.razor
+++ b/HVZ.Web/Shared/Navigation/Footer.razor
@@ -1,13 +1,4 @@
-@*<div class="position-sticky sticky-bottom d-none d-md-block">
-    anything that should stick to the bottom of the screen goes here
-    
-</div>*@
-<div class="container d-none d-md-block" style="
-    position:sticky;
-    position:-webkit-sticky;
-    bottom:2px;">
-    @* Sticky footer content goes here*@
-</div>
+
 <footer class="navbar d-none d-md-block container" >
     <hr>
     <div class="d-none d-md-block">
@@ -15,8 +6,7 @@
         
             <div class="d-flex justify-content-center align" style="align-items:center;">
                 <a class="navbar-brand text-muted" href="/">PlayHVZ</a>
-                @* Enable when github is ready to be displayed to end users *@
-                <a href="https://www.github.com/playhvzorg/hvz" target="_blank" class="nav-link text-muted"><i class="fa-brands fa-github"></i> Github</a>
+                <a href="https://www.github.com/playhvzorg/hvz" target="_blank" class="nav-link mx-1 text-muted"><i class="fa-brands fa-github"></i> Github</a>
                 <a href="/termsofservice" target="_blank" class="nav-link text-muted mx-1 align-text-bottom"><i class="fa-solid fa-book"></i> Terms of Service</a>
                 <a href="/privacy" target="_blank" class="nav-link text-muted mx-1"><i class="fa-regular fa-address-card"></i> Privacy</a>
             </div>

--- a/HVZ.Web/Shared/Navigation/Footer.razor
+++ b/HVZ.Web/Shared/Navigation/Footer.razor
@@ -6,7 +6,7 @@
     position:sticky;
     position:-webkit-sticky;
     bottom:2px;">
-    <p class="text-muted">Footer Sticky</p>
+    @* Sticky footer content goes here*@
 </div>
 <footer class="navbar d-none d-md-block container" >
     <hr>
@@ -14,9 +14,9 @@
         <div class="container">
         
             <div class="d-flex justify-content-center align" style="align-items:center;">
-                @* Enable when github is ready to be displayed to end users *@
                 <a class="navbar-brand text-muted" href="/">PlayHVZ</a>
-                @*<a href="https://www.github.com/playhvzorg/hvz" target="_blank" class="nav-link text-muted"><i class="fa-brands fa-github"></i> Github</a>*@
+                @* Enable when github is ready to be displayed to end users *@
+                <a href="https://www.github.com/playhvzorg/hvz" target="_blank" class="nav-link text-muted"><i class="fa-brands fa-github"></i> Github</a>
                 <a href="/termsofservice" target="_blank" class="nav-link text-muted mx-1 align-text-bottom"><i class="fa-solid fa-book"></i> Terms of Service</a>
                 <a href="/privacy" target="_blank" class="nav-link text-muted mx-1"><i class="fa-regular fa-address-card"></i> Privacy</a>
             </div>


### PR DESCRIPTION
* Remove Theme Toggle from About page
* Remove "Footer Sticky" placeholder from footer
* Enable github link in footer
* Set `User.CreatedAt` when a new User is created
* Filter out OZ status messages for unauthorized users
* Fix `User` information not being properly updated for virtual scroll in players list
* Center placeholder text for homepage when viewing on desktop